### PR TITLE
Add Github /raw link support

### DIFF
--- a/htmlpreview.js
+++ b/htmlpreview.js
@@ -2,7 +2,7 @@
 	
 	var previewForm = document.getElementById('previewform');
 
-	var url = location.search.substring(1).replace(/\/\/github\.com/, '//raw.githubusercontent.com').replace(/\/blob\//, '/'); //Get URL of the raw file
+	var url = location.search.substring(1).replace(/\/\/github\.com/, '//raw.githubusercontent.com').replace(/\/blob\//, '/').replace(/\/raw\//, '/'); //Get URL of the raw file
 
 	var replaceAssets = function () {
 		var frame, a, link, links = [], script, scripts = [], i, href, src;


### PR DESCRIPTION
Hi!

While I was playing with htmlpreview, I realized that the links in the form of github.com / author / repo / raw / ..... , doesn't open. I think this problem can be solved by replacing the "/raw" part, similar to how htmlpreview opens "/blob" links.