### PR TITLE
Try fetching without proxy first

### DIFF
--- a/htmlpreview.js
+++ b/htmlpreview.js
@@ -89,6 +89,7 @@
 	
 	var fetchProxy = function (url, options, i) {
 		var proxy = [
+			'', // try without proxy first
 			'https://cors-anywhere.herokuapp.com/',
 			'https://yacdn.org/proxy/',
 			'https://api.codetabs.com/v1/proxy/?quest='
@@ -104,10 +105,7 @@
 	};
 
 	if (url && url.indexOf(location.hostname) < 0)
-		fetch(url).then(function (res) {
-			if (!res.ok) throw new Error('Cannot load ' + url + ': ' + res.status + ' ' + res.statusText);
-			return res.text();
-		}).then(loadHTML).catch(function (error) {
+		fetchProxy(url, null, 0).then(loadHTML).catch(function (error) {
 			console.error(error);
 			previewForm.style.display = 'block';
 			previewForm.innerText = error;


### PR DESCRIPTION
When fetching a resource, try directly first. If it throws an error, then try with proxies.
Fixes #95
Should also reduce drastically the petitions to the proxy servers (will only be made if the non-proxy fails)


[Note: I tested it with some urls, but probably more tests are needed before merge]

Edit: test links:
https://trianguloy.github.io/htmlpreview.github.com/?https://www.dropbox.com/s/mgw65rktedx4pjl/Hello%32world.html?raw=1
https://trianguloy.github.io/htmlpreview.github.com/?https://github.com/twbs/bootstrap/gh-pages/2.3.2/index.html
https://trianguloy.github.io/htmlpreview.github.com/?https://github.com/documentcloud/backbone/blob/master/examples/todos/index.html