### PR TITLE
Delete no-longer-running yacdn.org proxy.

### DIFF
--- a/htmlpreview.js
+++ b/htmlpreview.js
@@ -90,7 +90,6 @@
 	var fetchProxy = function (url, options, i) {
 		var proxy = [
 			'https://cors-anywhere.herokuapp.com/',
-			'https://yacdn.org/proxy/',
 			'https://api.codetabs.com/v1/proxy/?quest='
 		];
 		return fetch(proxy[i] + url, options).then(function (res) {

--- a/htmlpreview.js
+++ b/htmlpreview.js
@@ -89,7 +89,6 @@
 	
 	var fetchProxy = function (url, options, i) {
 		var proxy = [
-			'https://cors-anywhere.herokuapp.com/',
 			'https://api.codetabs.com/v1/proxy/?quest='
 		];
 		return fetch(proxy[i] + url, options).then(function (res) {


### PR DESCRIPTION
yacdn.org has been down for some time.  Having it in the list of proxies means that attempting to view generated HTML can take a long time, before connection attempts time out.

Signed-off-by: Peter Chubb <peter.chubb@unsw.edu.au>