### PR TITLE
Use relative path to htmlpreview.js to allow publishing from forks

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,6 @@
 		<p>or prepend to the URL: <code><strong>http://htmlpreview.github.io/?</strong>https://github.com/twbs/bootstrap/blob/gh-pages/2.3.2/index.html</code></p>
 		<p id="footer">Developed by <a href="https://github.com/niutech">niu tech</a> | Contribute on <a href="https://github.com/htmlpreview/htmlpreview.github.com">GitHub</a></p>
 	</form>
-	<script src="/htmlpreview.js"></script>
+	<script src="htmlpreview.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This patch allows publishing to pages using URL: https://forker.github.io/htmlpreview.github.com/

It works in Firefox 116 and Chrome 116